### PR TITLE
Move vpim_icalendar gemspec into its own file

### DIFF
--- a/gemspec.rb
+++ b/gemspec.rb
@@ -1,0 +1,12 @@
+
+def info(spec)
+  {
+    :author => "Sam Roberts",
+    :email => "vieuxtech@gmail.com",
+    :homepage => "http://vpim.rubyforge.org",
+    :rubyforge_project => "vpim",
+  }.each do |key, value|
+    spec.send(key.to_s + "=", value)
+  end
+end
+

--- a/vpim.gemspec
+++ b/vpim.gemspec
@@ -1,19 +1,9 @@
 require 'ubygems'
 require 'pp'
 require 'rake'
+require './gemspec'
 
-def info(s)
-  {
-    :author => "Sam Roberts",
-    :email => "vieuxtech@gmail.com",
-    :homepage => "http://vpim.rubyforge.org",
-    :rubyforge_project => "vpim",
-  }.each do |k,v|
-    s.send(k.to_s+"=", v)
-  end
-end
-
-spec_vpim = Gem::Specification.new do |s|
+Gem::Specification.new do |s|
   info(s)
   s.name              = "vpim"
   s.version           = `ruby stamp.rb`

--- a/vpim_icalendar.gemspec
+++ b/vpim_icalendar.gemspec
@@ -1,0 +1,14 @@
+require './gemspec'
+
+Gem::Specification.new do |s|
+  info(s)
+  s.name              = "vpim_icalendar"
+  s.version           = "1.1"
+  s.summary           = "Virtual gem depending on vPim's iCalendar support for ruby"
+  s.description       = <<'---'
+This is a virtual gem, it exists to depend on vPim, which provides iCalendar
+support for ruby. You can install vPim directly.
+---
+  s.add_dependency("vpim")
+end
+


### PR DESCRIPTION
This is a proposed fix for issue #9, splitting the gemspecs for `vpim` and `vpim_icalendar` into their own separate files in order to support installation via `:git` in Gemfiles.
