### PR TITLE
Split decoded ADR value instead of raw value

### DIFF
--- a/lib/vpim/vcard.rb
+++ b/lib/vpim/vcard.rb
@@ -153,7 +153,7 @@ module Vpim
       def Address.decode(card, field) #:nodoc:
         adr = new
 
-        parts = Vpim.decode_text_list(field.value_raw, ';')
+        parts = Vpim.decode_text_list(field.value, ';')
 
         @@adr_parts.each_with_index do |part,i|
           adr.instance_variable_set(part, parts[i] || '')


### PR DESCRIPTION
The vCard address (ADR) line has multiple parameters (separated by
semicolons). If those parameters are encoded they have to be decoded
before splitting the and parsing the values.

test/test_vcard.rb ran without trouble:
`Run options:`
` `
`# Running tests:`
` `
`Finished tests in 0.424437s, 65.9698 tests/s, 409.9551 assertions/s.       `
`28 tests, 174 assertions, 0 failures, 0 errors, 0 skips`
` `
`ruby -v: ruby 2.1.2p95 (2014-05-08) [i386-linux-gnu]`
