### PR TITLE
fix 'invalid multibyte escape' error

### DIFF
--- a/lib/vpim/rfc2425.rb
+++ b/lib/vpim/rfc2425.rb
@@ -1,4 +1,4 @@
-# -*- encoding : utf-8 -*-
+# -*- encoding : binary -*-
 =begin
   Copyright (C) 2008 Sam Roberts
 
@@ -299,11 +299,11 @@ module Vpim
   end
 
   def Vpim.encode_paramvalue(value)
-    case value
+    case value.force_encoding("BINARY")
     when %r{\A#{Bnf::SAFECHAR}*\z}
-      value
+      value.force_encoding("utf-8")
     when %r{\A#{Bnf::QSAFECHAR}*\z}
-      '"' + value + '"'
+      '"' + value.force_encoding("utf-8") + '"'
     else
       raise Vpim::Unencodeable, "param-value #{value.inspect}"
     end


### PR DESCRIPTION
### Working with Ruby 2.1.5
- `# -*- encoding : binary -*-` fixed my 'invalid multibyte escape' error, like it did in [Fix invalid multi-byte escape errors on ruby 1.9](https://github.com/sam-github/vpim/commit/890549b93d2e55e5a43ad3a1dc73c4d061a77cff).
- But then I ran into another `Encoding::CompatibilityError: incompatible encoding regexp match (ASCII-8BIT regexp with UTF-8 string)` fixed with `value.force_encoding "BINARY"` and `value.force_encoding("utf-8")`.
- I admit I just pattern matched and don't understand what's going on in detail.
- I guess the following method has to be treated equally (but my code doesn't touch it):

```
  def Vpim.encode_paramtext(value)
    case value
    when %r{\A#{Bnf::SAFECHAR}*\z}
      value
    else
      raise Vpim::Unencodeable, "paramtext #{value.inspect}"
    end
  end
```
- And perhaps other Vpim.decode_X methods containing `%r{…}`, too.
- I'm still trying to get the vpim tests running…
