### PR TITLE
Fix 'invalid multibyte escape' error

### DIFF
--- a/lib/vpim/rfc2425.rb
+++ b/lib/vpim/rfc2425.rb
@@ -291,7 +291,7 @@ module Vpim
   # quoted-string      = DQUOTE *QSAFE-CHAR DQUOTE
   def Vpim.encode_paramtext(value)
     case value
-    when %r{\A#{Bnf::SAFECHAR}*\z}
+    when %r{\A#{Bnf::SAFECHAR}*\z}n
       value
     else
       raise Vpim::Unencodeable, "paramtext #{value.inspect}"
@@ -300,9 +300,9 @@ module Vpim
 
   def Vpim.encode_paramvalue(value)
     case value
-    when %r{\A#{Bnf::SAFECHAR}*\z}
+    when %r{\A#{Bnf::SAFECHAR}*\z}n
       value
-    when %r{\A#{Bnf::QSAFECHAR}*\z}
+    when %r{\A#{Bnf::QSAFECHAR}*\z}n
       '"' + value + '"'
     else
       raise Vpim::Unencodeable, "param-value #{value.inspect}"


### PR DESCRIPTION
I haven't run tests, since gem doesn't specify development dependencies.
However this patch fixes issue #5 for me and I haven't noticed other issued so far.

Please review this patch.