### PR TITLE
fix wrong call of casecmp

### DIFF
--- a/lib/vpim/field.rb
+++ b/lib/vpim/field.rb
@@ -353,7 +353,7 @@ module Vpim
       # - boolean:
       # - float:
       def kind?(kind)
-        Vpim::Methods.casecmp?(self.kind == kind)
+        Vpim::Methods.casecmp?(self.kind, kind)
       end
 
       # Is one of the values of the TYPE parameter of this field +type+? The


### PR DESCRIPTION
Vpim::Methods.casecomp is called with a single argument (str0 == str1). 
It needs two argument, the two strings to be compared.
Obvious error is obvious.